### PR TITLE
Add rickroll function to fix issue #42

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,6 +7,13 @@ window.addEventListener("DOMContentLoaded", (load) => {
   localStorage.setItem("counter", (visit += 1));
 });
 
+function func()
+{
+  document.getElementById('embed').style.display='inline-block';
+  document.getElementById('h1').scrollIntoView();
+  new Audio("epic.mp3").play();
+  document.getElementById('plus').style.display='none';
+}
 
 window.addEventListener('DOMContentLoaded',(load)=>{
  let visit=Number(localStorage.getItem('counter'))


### PR DESCRIPTION
Issue #42 says that the rickroll button in the bottom right of the page stopped working, possibly due to issues while merging. Turns out, the entire rickroll function got deleted. I went into the history of `script.js` and found the original function and put it back where it was originally. Yes, I got rickrolled while testing my changes.