### PR TITLE
General styling improvements 

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="dark light">
-  <meta property="og:description" content="Discover the joy of open source!">
+  <meta property="og:description" content="Discover the Joy of Open-source">
   <meta property="og:title" content="Station - A STTN Production">
   <meta property="og:image" content="https://station-team.netlify.app/images/coding-photo1.jpg">
   <meta property="twitter:card" content="summary">
-  <meta property="twitter:description" content="Discover the joy of open source!">
+  <meta property="twitter:description" content="Discover the Joy of Open-source!">
   <meta property="twitter:site" content="https://station-team.netlify">
   <meta property="twitter:title" content="Station - A STTN Production">
   <meta property="twitter:image" content="https://station-team.netlify.app/images/coding-photo1.jpg">
@@ -26,7 +26,7 @@
   <div class="container">
     <section class="hero-section">
       <div class="hero-content">
-        <h1 class="hero-title">Discover The Joy of Open-source!</h1>
+        <h1 class="hero-title">Discover the Joy of Open-source!</h1>
         <div class="hero-description">
           <p>Learn to work in a development team by making small contributions.</p>
           <p>Join us on GitHub to start contibuting or network with other developers on Discord.</p>
@@ -34,7 +34,7 @@
         <div class="hero-btns">
           <a class="hero-button" href="https://github.com/jeffreycharters/station" target="_blank">Start Contibuting!
             &raquo;</a>
-          <a class="hero-button--outline"  href="https://discord.gg/NhAfhBnh8g" target="_blank">Join Discord</a>
+          <a class="hero-button--outline"  href="https://discord.gg/NhAfhBnh8g" target="_blank">Join Our Discord!</a>
         </div>
 
         <img src="./assets/images/hero-circles-sm.svg" class="hero-svg" alt="svg">

--- a/script.js
+++ b/script.js
@@ -44,6 +44,9 @@ icons.forEach(function (e) {
       root.style.setProperty('--content','black');
       
       document.querySelector("body").classList.add("light-mode");
+      
+      document.querySelector(".hero-button--outline").classList.add("light-mode");
+
     } else {
       container.classList.remove("light-mode");
       links[1].style.color = null;
@@ -53,7 +56,9 @@ icons.forEach(function (e) {
       links.forEach((e) => e.classList.remove("link-light-mode"));
       document.querySelector("body").classList.remove("light-mode");
       root.style.setProperty('--bgc','black');
-      root.style.setProperty('--content','white');
+      root.style.setProperty('--content', 'white');
+      
+      document.querySelector(".hero-button--outline").classList.remove("light-mode");
     }
   });
 });

--- a/style.css
+++ b/style.css
@@ -21,6 +21,8 @@ body {
   padding: 0;
   box-sizing: border-box;
   font-family: "Montserrat", sans-serif;
+  background-color: rgb(22, 22, 23);
+  color: white;
 }
 
 /* Editing Scrollbar */
@@ -50,7 +52,7 @@ body {
   margin: auto;
   /*border: 0.1vh solid paleturquoise;*/
   font-size: 2rem;
-  padding: 1em;
+  padding: 2em 1em;
 }
 
 /* Universal style for h1 */
@@ -98,7 +100,7 @@ h1 {
   font-style: normal;
   font-weight: 400;
   font-size: 20px;
-  margin: 0;
+  margin: 13px 0;
 }
 
 .hero-btns {
@@ -108,7 +110,7 @@ h1 {
 }
 .hero-btns a {
   font-size: 1.5rem;
-  font-weight: 500;
+  font-weight: bold;
   padding: 12px 32px;
   border: 2px solid #292929;
   border-radius: 5px;
@@ -127,6 +129,11 @@ h1 {
   color: #fff;
   border: 2px solid #292929;
 }
+
+.hero-button--outline.light-mode {
+  color: black;
+}
+
 .hero-button:hover,
 .hero-button--outline:hover {
   background: linear-gradient(to right, #f32170, #ff6b08, #cf23cf, #eedd44);
@@ -410,12 +417,15 @@ input[type="color"]::-webkit-color-swatch {
   }
 }
 
-/* Small Tablet Styles */
+/* Small Tablet and Mobile Styles */
+
+/* 
+  NOTE: Moved mobile styles to here so that the text on
+  the hero section buttons doesn't wrap, which just looks
+  better on not so small phones! 
+*/
+
 @media screen and (max-width: 550px) /* .embed { height: 360px; width: 480px; } */ {
-  .container {
-    width: 100%;
-    max-width: 100%;
-  }
   /* I chose 550px because the list breaks at around that pixel size. */
 
   .fave-container {
@@ -431,19 +441,18 @@ input[type="color"]::-webkit-color-swatch {
     top: 0;
     left: 0;
   }
-}
 
-/* Mobile Styles*/
-@media screen and (max-width: 400px) /* .embed { height: 360px; width: 480px; } */ {
   .hero-btns {
     flex-direction: column;
     gap: 12px;
     width: 70%;
     margin: auto;
   }
+
   .hero-btns a {
     width: 100%;
   }
+
 }
 
 .testinomials {


### PR DESCRIPTION
## Spelling
 - Page title and meta tags:
   -  "Open-source" is commonly spelled with a hyphen and a capitalized "O" when used at the start of a sentence - see ["Open-source software" on Wikipedia](https://en.wikipedia.org/wiki/Open-source_software)
   - Updated sentences to match proper [Title Case](https://en.wikipedia.org/wiki/Title_case)
 - Hero section button: "Join Our Discord!" is a more descriptive CTA than "Join Discord"
## Styling
  - Added dark BG and white text color as the default - was experiencing issues with dark mode on desktop where the `body`'s background color just changed from white to a light gray hue
  - Adding vertical padding to `.container` so it doesn't get obfuscated by the dark/light mode toggle icon
  - Changed `font-weight` on hero section buttons from `500` to `bold` so they stand out more
  - Fixed issue where the text color on the Discord CTA hero button didn't change when toggling themes
  - Grouped mobile and small tablet media queries together - this way, the text on the hero section buttons doesn't wrap and looks less cluttered on all phones, regardless of size, as well as small tablets